### PR TITLE
Install the tini provided by debian in the dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -64,40 +64,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-#  clippy:
-#    name: Clippy
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#            toolchain: nightly
-#            components: clippy
-#            override: true
-#      - uses: actions-rs/clippy-check@v1
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-
-#  publish_crate:
-#    name: Publish Crate
-#    # Don't publish unless all the checks pass.
-#    needs: [check, test, clippy, rustfmt]
-#    # Only publish for tags
-#    if: ${{ startsWith(github.event.ref, 'refs/tags/') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout sources
-#        uses: actions/checkout@v1
-#
-#      - name: cargo login
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: login
-#          args: ${{ secrets.CARGO_TOKEN }}
-#
-#      - name: publish
-#        run: cargo publish --no-verify
-
   docker:
     name: Push Docker Image
     needs: [check, test]
@@ -105,7 +71,7 @@ jobs:
     steps:
       -
         name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -133,7 +99,7 @@ jobs:
 
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 
 RUN \
-	apt-get update \
+  apt-get update \
   && apt-get -y install --no-install-recommends \
     ca-certificates \
     tini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/rust:slim-buster AS build
+FROM public.ecr.aws/docker/library/rust:slim-bookworm AS build
 
 ENV PKG_CONFIG_ALLOW_CROSS=1
 
@@ -12,7 +12,7 @@ RUN \
 	cp "target/release/rudolfs" /build/ && \
 	strip /build/rudolfs
 
-FROM public.ecr.aws/debian/debian:buster-slim AS run
+FROM public.ecr.aws/debian/debian:bookworm-slim AS run
 
 EXPOSE 8080
 VOLUME ["/data"]
@@ -21,19 +21,17 @@ COPY --from=build /build/ /
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN \
-	apt-get update && \
-	apt-get -y install ca-certificates && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
-# Use Tini as our PID 1. This will enable signals to be handled more correctly.
-#
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
-RUN chmod +x /tini
+RUN \
+	apt-get update \
+  && apt-get -y install --no-install-recommends \
+    ca-certificates \
+    tini \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crttt
 
-ENTRYPOINT ["/tini", "--", "/rudolfs"]
+# Use Tini as our PID 1. This will enable signals to be handled more correctly.
+ENTRYPOINT ["/usr/bin/tini", "--", "/rudolfs"]
 CMD ["--cache-dir", "/data"]


### PR DESCRIPTION
The Dockerfile and CI build both `arm64` and `amd64` versions. However the `tini` binary that was installed was only for `amd64`

This PR changes the tini version from pulling the binary from the github release page to installing the version distributed by Debian maintainers with `apt-get`.  There are some minor changes here: 1) I choose to not use the statically compiled binary because I trust the Debian maintainers to get the libc requirements all lined up, and 2) it installs the executable to `/usr/bin/tini`, https://github.com/krallin/tini?tab=readme-ov-file#debian  I decided to just leave it there, but we could move it to `/tini` if we care.

Additionally buster debian is EoL so I bumped it to bookworm

